### PR TITLE
Update verslag requirements werkgroep 8 maart met notulen

### DIFF
--- a/werkgroep requiremens/verslagen/20240308.md
+++ b/werkgroep requiremens/verslagen/20240308.md
@@ -1,3 +1,37 @@
+# Aanwezig
+* Ron Obbens
+* Marc Hoekstra
+* Leo van der Lubbe
+* Albert VLug
+* Sergej van Middenkoop
+* Steven van der Vegt
+* Guido van 't Noordende
+* Marc Smits
+* Johan Snijders
+* Vincent van de Berg
+
+## Afwezig
+* Lex Pater
+* Erik Koppelaar
+* Erik Zwarter
+* Peter Jansen
+
+# Opening
+In principe kan iedereen nu in Github
+
+VWS komt nog met een voorstel voor het verbeteren van het proces in dw werkgroep
+
+# Verslag
+Geen opmerkingen op  het verslag
+
+# Aan de Slag
+VWS heeft Sergej gevraagd om de werkgroep te begeleiden. N.a.v. de vorige keer vond VWS en de facilitators het wenselijk om de meest ervaren facilitator ons te laten helpen. Dit betekent dat nu Sergej en Steven vandaag zullen ondersteunen. We weten dat hier bezwaren tegen zijn geuit maar VWS stelt voor de kiezen voor de beste ondersteuning boven iemand achtergrond. We realiseren ons dat de vertegenwoordig vanuit de IZA er vandaag niet is en vanuit die kant vorige keer bezwaren waren. Daarom moeten we hier een volgende keer op terugkomen
+
+Verder verslag in de requirements
+
+# WVVTK
+We gaan op zoek naar een ander moment als vrijdagmiddag. Dit is voor teveel mensen een issue. VWS neemt hiertoe het initiatief.
+
 # stukken werkgroep 8 maart 2024
 
 [20240306 Notitie werkwijze Toestemming Requirements (aangepast 18 mrt).docx](https://github.com/minvws/generiekefuncties-toestemming/files/14665938/20240306.Notitie.werkwijze.Toestemming.Requirements.aangepast.18.mrt.docx)


### PR DESCRIPTION
Notulen uit #52 toegevoegd aan het al bestaande verslag met de stukken. Die file uit #52 had een andere bestandsnaamformaat en had geen `.md` extensie. Daarom een nieuw PR.

Closes #52.